### PR TITLE
Add more clients

### DIFF
--- a/client/authorizer/authorizer.go
+++ b/client/authorizer/authorizer.go
@@ -5,8 +5,9 @@ import (
 
 	"github.com/aserto-dev/aserto-go/client"
 	"github.com/aserto-dev/go-grpc/aserto/authorizer/directory/v1"
+	"github.com/aserto-dev/go-grpc/aserto/authorizer/policy/v1"
 	"github.com/aserto-dev/go-grpc/aserto/common/info/v1"
-	"github.com/aserto-dev/go-grpc/aserto/tenant/policy/v1"
+	"google.golang.org/grpc"
 
 	"github.com/aserto-dev/go-grpc-authz/aserto/authorizer/authorizer/v1"
 
@@ -45,4 +46,9 @@ func New(ctx context.Context, opts ...client.ConnectionOption) (*Client, error) 
 		Policy:     policy.NewPolicyClient(connection.Conn),
 		Info:       info.NewInfoClient(connection.Conn),
 	}, err
+}
+
+// Connection returns the underlying grpc connection.
+func (c *Client) Connection() grpc.ClientConnInterface {
+	return c.conn.Conn
 }

--- a/client/connection_test.go
+++ b/client/connection_test.go
@@ -39,6 +39,7 @@ func (d *dialRecorder) DialContext(
 	tlsConf *tls.Config,
 	callerCreds credentials.PerRPCCredentials,
 	connection *Connection,
+	options []grpc.DialOption,
 ) (grpc.ClientConnInterface, error) {
 	d.context = ctx
 	d.address = address
@@ -88,6 +89,18 @@ func TestWithInsecure(t *testing.T) {
 func TestWithTokenAuth(t *testing.T) {
 	recorder := &dialRecorder{}
 	newConnection(context.TODO(), recorder.DialContext, WithTokenAuth("<token>")) // nolint:errcheck
+
+	md, err := recorder.callerCreds.GetRequestMetadata(context.TODO())
+	assert.NoError(t, err)
+
+	token, ok := md["authorization"]
+	assert.True(t, ok)
+	assert.Equal(t, "bearer <token>", token)
+}
+
+func TestWithBearerTokenAuth(t *testing.T) {
+	recorder := &dialRecorder{}
+	newConnection(context.TODO(), recorder.DialContext, WithTokenAuth("bearer <token>")) // nolint:errcheck
 
 	md, err := recorder.callerCreds.GetRequestMetadata(context.TODO())
 	assert.NoError(t, err)

--- a/client/internal/credentials.go
+++ b/client/internal/credentials.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"context"
+	"strings"
 )
 
 // TokenAuth bearer token based authentication.
@@ -12,6 +13,13 @@ type TokenAuth struct {
 }
 
 func NewTokenAuth(token string) *TokenAuth {
+	pieces := strings.Split(token, " ")
+	if len(pieces) == 1 {
+		return &TokenAuth{
+			token: Bearer + " " + token,
+		}
+	}
+
 	return &TokenAuth{
 		token: token,
 	}
@@ -19,7 +27,7 @@ func NewTokenAuth(token string) *TokenAuth {
 
 func (t TokenAuth) GetRequestMetadata(ctx context.Context, in ...string) (map[string]string, error) {
 	return map[string]string{
-		Authorization: Bearer + " " + t.token,
+		Authorization: t.token,
 	}, nil
 }
 

--- a/client/registry/registry.go
+++ b/client/registry/registry.go
@@ -1,0 +1,37 @@
+package registry
+
+import (
+	"context"
+
+	"github.com/aserto-dev/aserto-go/client"
+	"github.com/aserto-dev/go-grpc/aserto/registry/v1"
+	"google.golang.org/grpc"
+
+	"github.com/pkg/errors"
+)
+
+// Client provides access to the Aserto registry services.
+type Client struct {
+	conn *client.Connection
+
+	// Registry provides methods for interacting with the registry service.
+	Registry registry.RegistryClient
+}
+
+// NewClient creates a Client with the specified connection options.
+func New(ctx context.Context, opts ...client.ConnectionOption) (*Client, error) {
+	connection, err := client.NewConnection(ctx, opts...)
+	if err != nil {
+		return nil, errors.Wrap(err, "create grpc client failed")
+	}
+
+	return &Client{
+		conn:     connection,
+		Registry: registry.NewRegistryClient(connection.Conn),
+	}, err
+}
+
+// Connection returns the underlying grpc connection.
+func (c *Client) Connection() grpc.ClientConnInterface {
+	return c.conn.Conn
+}

--- a/client/registrytenant/registrytenant.go
+++ b/client/registrytenant/registrytenant.go
@@ -1,0 +1,45 @@
+package registrytenant
+
+import (
+	"context"
+
+	"github.com/aserto-dev/aserto-go/client"
+	"github.com/aserto-dev/go-grpc/aserto/registry_tenant/v1"
+	"google.golang.org/grpc"
+
+	"github.com/pkg/errors"
+)
+
+// Client provides access to the Aserto registry tenant services.
+type Client struct {
+	conn *client.Connection
+
+	// Tenant provides methods for interacting with the tenant service.
+	Tenant registry_tenant.TenantClient
+
+	// Policy provides methods for interacting with the policy service.
+	Policy registry_tenant.PolicyClient
+
+	// PolicyRepo provides methods for interacting with the policy repository service.
+	PolicyRepo registry_tenant.PolicyRepoClient
+}
+
+// NewClient creates a Client with the specified connection options.
+func New(ctx context.Context, opts ...client.ConnectionOption) (*Client, error) {
+	connection, err := client.NewConnection(ctx, opts...)
+	if err != nil {
+		return nil, errors.Wrap(err, "create grpc client failed")
+	}
+
+	return &Client{
+		conn:       connection,
+		Tenant:     registry_tenant.NewTenantClient(connection.Conn),
+		Policy:     registry_tenant.NewPolicyClient(connection.Conn),
+		PolicyRepo: registry_tenant.NewPolicyRepoClient(connection.Conn),
+	}, err
+}
+
+// Connection returns the underlying grpc connection.
+func (c *Client) Connection() grpc.ClientConnInterface {
+	return c.conn.Conn
+}

--- a/client/tenant/tenant.go
+++ b/client/tenant/tenant.go
@@ -11,8 +11,10 @@ import (
 	connection "github.com/aserto-dev/go-grpc/aserto/tenant/connection/v1"
 	onboarding "github.com/aserto-dev/go-grpc/aserto/tenant/onboarding/v1"
 	policy "github.com/aserto-dev/go-grpc/aserto/tenant/policy/v1"
+	policy_builder "github.com/aserto-dev/go-grpc/aserto/tenant/policy_builder/v1"
 	profile "github.com/aserto-dev/go-grpc/aserto/tenant/profile/v1"
 	provider "github.com/aserto-dev/go-grpc/aserto/tenant/provider/v1"
+	registry "github.com/aserto-dev/go-grpc/aserto/tenant/registry/v1"
 	scc "github.com/aserto-dev/go-grpc/aserto/tenant/scc/v1"
 
 	"github.com/pkg/errors"
@@ -34,11 +36,17 @@ type Client struct {
 	// Policy provides methods for creating, listing, and deleting policy references.
 	Policy policy.PolicyClient
 
+	// PolicyBuilder provides methods for creating and managing policy builders.
+	PolicyBuilder policy_builder.PolicyBuilderClient
+
 	// Profile provides methods for managing user invitations.
 	Profile profile.ProfileClient
 
 	// Provider provides methods for viewing the providers available to create connections.
 	Provider provider.ProviderClient
+
+	// Registry provides methods for managing registry repositories.
+	Registry registry.RegistryClient
 
 	// SCC provides methods for interacting with a tenant's configured source-control repositories.
 	SCC scc.SourceCodeCtlClient
@@ -55,15 +63,17 @@ func New(ctx context.Context, opts ...client.ConnectionOption) (*Client, error) 
 	}
 
 	return &Client{
-		conn:        conn,
-		Account:     account.NewAccountClient(conn.Conn),
-		Connections: connection.NewConnectionClient(conn.Conn),
-		Onboarding:  onboarding.NewOnboardingClient(conn.Conn),
-		Policy:      policy.NewPolicyClient(conn.Conn),
-		Profile:     profile.NewProfileClient(conn.Conn),
-		Provider:    provider.NewProviderClient(conn.Conn),
-		SCC:         scc.NewSourceCodeCtlClient(conn.Conn),
-		Info:        info.NewInfoClient(conn.Conn),
+		conn:          conn,
+		Account:       account.NewAccountClient(conn.Conn),
+		Connections:   connection.NewConnectionClient(conn.Conn),
+		Onboarding:    onboarding.NewOnboardingClient(conn.Conn),
+		Policy:        policy.NewPolicyClient(conn.Conn),
+		PolicyBuilder: policy_builder.NewPolicyBuilderClient(conn.Conn),
+		Profile:       profile.NewProfileClient(conn.Conn),
+		Provider:      provider.NewProviderClient(conn.Conn),
+		Registry:      registry.NewRegistryClient(conn.Conn),
+		SCC:           scc.NewSourceCodeCtlClient(conn.Conn),
+		Info:          info.NewInfoClient(conn.Conn),
 	}, err
 }
 
@@ -72,6 +82,7 @@ func (c *Client) SetTenantID(tenantID string) {
 	c.conn.TenantID = tenantID
 }
 
+// Connection returns the underlying grpc connection.
 func (c *Client) Connection() grpc.ClientConnInterface {
 	return c.conn.Conn
 }


### PR DESCRIPTION
1. add registry, registry tenant clients
2. add WithChainUnaryInterceptor and WithChainStreamInterceptor options
3. support tokens that already contain `bearer`
4. set tenant-id middleware only if tenant id was provided. if setting it with empty tenant id, passing the tenant id via ctx does not work anymore