### PR TITLE
Identity object isn't shared across requeusts.

### DIFF
--- a/middleware/grpc/identity_test.go
+++ b/middleware/grpc/identity_test.go
@@ -35,13 +35,13 @@ func TestTypeAssignment(t *testing.T) {
 }
 
 func TestAssignmentOverride(t *testing.T) {
-	builder := (&IdentityBuilder{}).JWT().None()
+	identity := (&IdentityBuilder{}).JWT().None().build(context.TODO(), nil)
 
 	assert.Equal(
 		t,
 		Anon(),
 		(&IdentityBuilder{}).JWT().None().build(context.TODO(), nil),
-		builder.identity.Context().Type,
+		identity.Type,
 		"Expected NONE identity to override JWT",
 	)
 }

--- a/middleware/internal/identity.go
+++ b/middleware/internal/identity.go
@@ -9,6 +9,15 @@ type Identity struct {
 	context api.IdentityContext
 }
 
+func NewIdentity(identityType api.IdentityType, identity string) *Identity {
+	return &Identity{
+		context: api.IdentityContext{
+			Type:     identityType,
+			Identity: identity,
+		},
+	}
+}
+
 var _ middleware.Identity = (*Identity)(nil)
 
 func (id *Identity) JWT() middleware.Identity {


### PR DESCRIPTION
This makes `IdentityBuilder` immutable within the context of an incoming message, which makes it thread safe.
Callers can mutate it on the middleware as part of initialization, but then each individual request creates a new `Identity` object of its own.

Fixes https://www.pivotaltracker.com/story/show/181288483