### PR TITLE
Always include TenantID client interceptors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ dist/
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+# golangci
+.ext/

--- a/client/connection.go
+++ b/client/connection.go
@@ -98,16 +98,11 @@ func dialContext(
 	dialOptions := []grpc.DialOption{
 		grpc.WithTransportCredentials(credentials.NewTLS(tlsConf)),
 		grpc.WithBlock(),
+		grpc.WithChainUnaryInterceptor(connection.unary),
+		grpc.WithChainStreamInterceptor(connection.stream),
 	}
 	if callerCreds != nil {
 		dialOptions = append(dialOptions, grpc.WithPerRPCCredentials(callerCreds))
-	}
-
-	if connection.TenantID != "" {
-		dialOptions = append(dialOptions,
-			grpc.WithChainUnaryInterceptor(connection.unary),
-			grpc.WithChainStreamInterceptor(connection.stream),
-		)
 	}
 
 	dialOptions = append(dialOptions, options...)


### PR DESCRIPTION
This PR fixes https://www.pivotaltracker.com/story/show/181626143.

The client interceptors that add a tenant ID to outgoing requests must _always_ be included in new connections even when a tenant ID isn't specified at connection time because it may be added later using `SetTenantID`.