### PR TITLE
don't set tenant metadata if no tenant-id is passed

### DIFF
--- a/client/connection.go
+++ b/client/connection.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"crypto/tls"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/aserto-dev/aserto-go/client/internal"
@@ -195,6 +196,10 @@ func (c *Connection) stream(
 
 // setTenantContext returns a new context with the provided tenant ID embedded as metadata.
 func setTenantContext(ctx context.Context, tenantID string) context.Context {
+	if strings.TrimSpace(tenantID) == "" {
+		return ctx
+	}
+
 	return metadata.AppendToOutgoingContext(ctx, internal.AsertoTenantID, tenantID)
 }
 


### PR DESCRIPTION
If the tenantID is empty, do not append the `AsertoTenantID` to the context metadata.